### PR TITLE
Enhance pytest configuration with strict validation and markers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,10 +36,10 @@ jobs:
 
       # Run the full test suite against the built distributions to ensure integrity
       - name: Test (wheel)
-        run: uv run --isolated --no-project --with dist/*.whl --with pytest pytest -o addopts=
+        run: uv run --isolated --no-project --with dist/*.whl --with pytest pytest -o addopts='--tb=short --strict-markers --strict-config'
 
       - name: Test (source distribution)
-        run: uv run --isolated --no-project --with dist/*.tar.gz --with pytest pytest -o addopts=
+        run: uv run --isolated --no-project --with dist/*.tar.gz --with pytest pytest -o addopts='--tb=short --strict-markers --strict-config'
 
       - name: Publish
         run: uv publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,10 +36,10 @@ jobs:
 
       # Run the full test suite against the built distributions to ensure integrity
       - name: Test (wheel)
-        run: uv run --isolated --no-project --with dist/*.whl --with pytest pytest
+        run: uv run --isolated --no-project --with dist/*.whl --with pytest pytest -o addopts=
 
       - name: Test (source distribution)
-        run: uv run --isolated --no-project --with dist/*.tar.gz --with pytest pytest
+        run: uv run --isolated --no-project --with dist/*.tar.gz --with pytest pytest -o addopts=
 
       - name: Publish
         run: uv publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,10 @@ dev = [
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
+markers = [
+    "unit: fast, module-scoped unit tests",
+    "e2e: end-to-end calver_scm behaviour tests",
+]
 addopts = [
     "--tb=short",
     "--strict-markers",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,39 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+_SCOPE_MARKERS = ("unit", "e2e")
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Fail collection when tests are missing or mixing scope markers."""
+    missing_scope: list[str] = []
+    multiple_scope: list[str] = []
+
+    for item in items:
+        matched = [name for name in _SCOPE_MARKERS if item.get_closest_marker(name)]
+        if not matched:
+            missing_scope.append(item.nodeid)
+        elif len(matched) > 1:
+            multiple_scope.append(item.nodeid)
+
+    if not missing_scope and not multiple_scope:
+        return
+
+    errors: list[str] = []
+    if missing_scope:
+        errors.append(
+            "Tests missing scope marker (choose one: unit, e2e):\n- "
+            + "\n- ".join(missing_scope)
+        )
+    if multiple_scope:
+        errors.append(
+            "Tests with multiple scope markers (choose exactly one):\n- "
+            + "\n- ".join(multiple_scope)
+        )
+
+    raise pytest.UsageError("\n\n".join(errors))
+
+
 @pytest.fixture(autouse=True)
 def clear_config_cache() -> Generator[None, None, None]:
     """Clear cached config reads between tests for deterministic behaviour."""

--- a/tests/test_calver_version.py
+++ b/tests/test_calver_version.py
@@ -4,6 +4,8 @@ import pytest
 
 from calver_scm.calver_version import CalverVersion
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.parametrize(
     ("raw", "expected"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+pytestmark = pytest.mark.unit
+
+
 def test_enum_from_raw_accepts_instances_and_strings() -> None:
     """Coerce enum values from either already-typed or raw string input."""
     assert CalverMode.from_raw(CalverMode.MONTH) is CalverMode.MONTH

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import pytest
+
 from calver_scm.config import CalverConfig, CalverMode
 
 # noinspection PyProtectedMember
 from calver_scm.parser import _parse_tag, _release_components
+
+pytestmark = pytest.mark.unit
 
 
 def test_parse_tag_strips_prefix_and_parses_version() -> None:

--- a/tests/test_scheme_e2e.py
+++ b/tests/test_scheme_e2e.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
+pytestmark = pytest.mark.e2e
+
+
 @pytest.mark.parametrize(
     ("tag", "distance", "dirty", "today", "expected"),
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,6 +19,8 @@ from calver_scm.utils import (
     _token_value,
 )
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.mark.parametrize(
     ("token", "date", "expected"),


### PR DESCRIPTION
This pull request enforces stricter test scoping and improves test configuration. It introduces required scope markers (`unit` or `e2e`) for all tests, updates the pytest configuration to recognize these markers, and ensures that tests are properly categorized. Additionally, it standardizes test output options in CI workflows.

**Test scope enforcement and configuration:**

* Added a `pytest_collection_modifyitems` hook in `tests/conftest.py` to require every test to have exactly one scope marker (`unit` or `e2e`); raises a usage error if missing or multiple markers are found.
* Updated `pyproject.toml` to define `unit` and `e2e` markers in the pytest configuration.
* Added `pytestmark = pytest.mark.unit` or `pytest.mark.e2e` to all test modules to explicitly set their scope. 

**CI workflow improvements:**

* Updated `.github/workflows/publish.yml` to pass additional pytest options (`--tb=short --strict-markers --strict-config`) during test runs for consistent and strict test output.