### PR TITLE
Refactor CI workflows to separate build/test and publish steps

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -1,0 +1,43 @@
+name: Build distributions
+
+on:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Build and test distributions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Required for setuptools-scm to derive the version from Git history
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install
+
+      - name: Build
+        run: uv build
+
+      # Run the full test suite against the built distributions to ensure integrity
+      - name: Test (wheel)
+        run: uv run --isolated --no-project --with dist/*.whl --with pytest pytest -o addopts='--tb=short --strict-markers --strict-config'
+
+      - name: Test (source distribution)
+        run: uv run --isolated --no-project --with dist/*.tar.gz --with pytest pytest -o addopts='--tb=short --strict-markers --strict-config'
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,52 +1,19 @@
 name: Publish
 
 on:
-  pull_request:
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   build-and-test:
-    name: Build and test distributions
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/build-dist.yml
     permissions:
       contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          # Required for setuptools-scm to derive the version from Git history
-          fetch-depth: 0
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
-        with:
-          enable-cache: true
-
-      - name: Install Python
-        run: uv python install
-
-      - name: Build
-        run: uv build
-
-      # Run the full test suite against the built distributions to ensure integrity
-      - name: Test (wheel)
-        run: uv run --isolated --no-project --with dist/*.whl --with pytest pytest -o addopts='--tb=short --strict-markers --strict-config'
-
-      - name: Test (source distribution)
-        run: uv run --isolated --no-project --with dist/*.tar.gz --with pytest pytest -o addopts='--tb=short --strict-markers --strict-config'
-
-      - name: Upload distributions
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
 
   publish:
     name: Publish to PyPI
     needs: build-and-test
-    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,16 @@
 name: Publish
 
 on:
+  pull_request:
   release:
     types: [published]
   workflow_dispatch:
 
 jobs:
-  run:
-    name: Build and publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+  build-and-test:
+    name: Build and test distributions
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
     permissions:
-      # Required for Trusted Publishing
-      id-token: write
-      # Required for reading repository content
       contents: read
     steps:
       - name: Checkout
@@ -42,6 +37,31 @@ jobs:
       - name: Test (source distribution)
         run: uv run --isolated --no-project --with dist/*.tar.gz --with pytest pytest -o addopts='--tb=short --strict-markers --strict-config'
 
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build-and-test
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
       - name: Publish
-        if: github.event_name == 'release'
         run: uv publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,12 @@ name: Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   run:
     name: Build and publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -42,4 +43,5 @@ jobs:
         run: uv run --isolated --no-project --with dist/*.tar.gz --with pytest pytest -o addopts='--tb=short --strict-markers --strict-config'
 
       - name: Publish
+        if: github.event_name == 'release'
         run: uv publish


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing to PyPI by splitting the build/test and publish steps into separate jobs, improving CI reliability and artifact handling. It also expands workflow triggers to include pull requests and manual dispatches.

**Workflow improvements:**

* Split the workflow into two jobs: `build-and-test` (which builds and tests distributions, then uploads them as artifacts) and `publish` (which downloads the built distributions and publishes them to PyPI). This makes the workflow more modular and reliable.
* Added an artifact upload step in `build-and-test` and a corresponding download step in `publish` to ensure only tested artifacts are published.

**Trigger and configuration changes:**

* Expanded workflow triggers to include `pull_request` and `workflow_dispatch`, allowing the workflow to run on PRs and manual triggers in addition to releases.
* Updated job and environment configuration for clarity and to match the new job structure.