### PR TITLE
Refine README formatting and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # calver-scm
 
-**Automatic, date-based versioning for Python projects â€” powered by your Git history.**
+**Automatic, date-based versioning for Python projects, powered by your Git history.**
 
 [![PyPI version][pypi-version-badge]][pypi-link]
 [![PyPI downloads][pypi-downloads-badge]][pypi-link]
@@ -21,17 +21,17 @@
 
 ---
 
-`calver-scm` is a [setuptools-scm](https://github.com/pypa/setuptools_scm) plugin that generates [CalVer](https://calver.org) version strings directly from your Git tags and commit history. No `__version__` files to maintain, no manual bumping â€” just tag and go.
+`calver-scm` is a [setuptools-scm](https://github.com/pypa/setuptools_scm) plugin that generates [CalVer](https://calver.org) version strings directly from your Git tags and commit history. No `__version__` files to maintain, no manual bumping; just tag and go.
 
 Versions look like this:
 
 ```
-2026.04.0          â† clean tag, April 2026, patch 0
-2026.04.1.dev3     â† 3 commits after that tag, still April, patch incremented
-2026.05.0.dev3     â† 3 commits after an old tag, month rolled over, patch reset
-2026.04.15.0       â† day mode: clean tag on the 15th
-2026.04.15.1.dev2  â† day mode: 2 commits after a tag on the same day
-2026.04.0.dev12    â† no tag yet, 12 commits in
+2026.04.0          -> clean tag, April 2026, patch 0
+2026.04.1.dev3     -> 3 commits after that tag, still April, patch incremented
+2026.05.0.dev3     -> 3 commits after an old tag, month rolled over, patch reset
+2026.04.15.0       -> day mode: clean tag on the 15th
+2026.04.15.1.dev2  -> day mode: 2 commits after a tag on the same day
+2026.04.0.dev12    -> no tag yet, 12 commits in
 ```
 
 ---
@@ -71,7 +71,7 @@ dynamic = ["version"]
 source = "vcs"
 
 [tool.hatch.version.raw-options]
-version_scheme = "calver_scm"
+version_scheme = "calver-scm"
 local_scheme   = "dirty-tag"
 ```
 
@@ -88,7 +88,7 @@ build-backend = "setuptools.build_meta"
 dynamic = ["version"]
 
 [tool.setuptools_scm]
-version_scheme = "calver_scm"
+version_scheme = "calver-scm"
 local_scheme   = "dirty-tag"
 ```
 
@@ -158,10 +158,10 @@ Tag any of the recognised PEP 440 aliases and it is normalised automatically:
 | `preview` / `pre` / `c` / `rc` | `rc`             |
 
 ```
-v2026.04.0a1     â†’ 2026.04.0a1
-v2026.04.0beta2  â†’ 2026.04.0b2
-v2026.04.0pre1   â†’ 2026.04.0rc1
-v2026.04.0rc1    â†’ 2026.04.0rc1
+v2026.04.0a1     -> 2026.04.0a1
+v2026.04.0beta2  -> 2026.04.0b2
+v2026.04.0pre1   -> 2026.04.0rc1
+v2026.04.0rc1    -> 2026.04.0rc1
 ```
 
 ### Post-release suffixes (`post`)
@@ -172,10 +172,10 @@ v2026.04.0rc1    â†’ 2026.04.0rc1
 | `post-N` / `postN`     | `postN`          |
 
 ```
-v2026.04.0-r1     â†’ 2026.04.0.post1
-v2026.04.0.rev2   â†’ 2026.04.0.post2
-v2026.04.0.post-3 â†’ 2026.04.0.post3
-v2026.04.0.post3  â†’ 2026.04.0.post3
+v2026.04.0-r1     -> 2026.04.0.post1
+v2026.04.0.rev2   -> 2026.04.0.post2
+v2026.04.0.post-3 -> 2026.04.0.post3
+v2026.04.0.post3  -> 2026.04.0.post3
 ```
 
 ### Dev suffixes (`dev`)
@@ -183,12 +183,12 @@ v2026.04.0.post3  â†’ 2026.04.0.post3
 | Tag suffix      | Canonical output |
 |-----------------|------------------|
 | `dev` (bare)    | `dev0`           |
-| `dev-N` / `devN`| `devN`           |
+| `dev-N` / `devN` | `devN`          |
 
 ```
-v2026.04.0.dev    â†’ 2026.04.0.dev0
-v2026.04.0.dev-4  â†’ 2026.04.0.dev4
-v2026.04.0.dev4   â†’ 2026.04.0.dev4
+v2026.04.0.dev    -> 2026.04.0.dev0
+v2026.04.0.dev-4  -> 2026.04.0.dev4
+v2026.04.0.dev4   -> 2026.04.0.dev4
 ```
 
 ### Local version segment (`+`)
@@ -197,8 +197,8 @@ A `+local` segment on a tag is preserved as-is. PEP 440 normalises
 underscores to dots within local identifiers:
 
 ```
-v2026.04.0+abc            â†’ 2026.04.0+abc
-v2026.04.0+linux.x86_64   â†’ 2026.04.0+linux.x86.64
+v2026.04.0+abc            -> 2026.04.0+abc
+v2026.04.0+linux.x86_64   -> 2026.04.0+linux.x86.64
 ```
 
 > **Note:** The `+local` segment on a *tag* is distinct from the `+dirty`
@@ -210,7 +210,7 @@ v2026.04.0+linux.x86_64   â†’ 2026.04.0+linux.x86.64
 All segments can be combined and are each normalised independently:
 
 ```
-v2026.04.0rc1.post2.dev3+local â†’ 2026.04.0rc1.post2.dev3+local
+v2026.04.0rc1.post2.dev3+local -> 2026.04.0rc1.post2.dev3+local
 ```
 
 ---
@@ -224,7 +224,7 @@ Add a `[tool.calver-scm]` section to `pyproject.toml` to customise behaviour. Al
 mode       = "month"   # "year" | "month" | "week" | "day"
 scheme     = "YYYY.0M" # optional token scheme; defaults from mode
 patch      = true      # auto-increment patch within a period
-fallback   = "dev"     # "dev" | "date" â€” when no tag exists
+fallback   = "dev"     # "dev" | "date" (when no tag exists)
 tag_prefix = "v"       # prefix stripped when reading tags
 timezone   = "UTC"     # "UTC" (default), "local", or IANA tz name
 ```
@@ -245,31 +245,31 @@ Supported `scheme` tokens follow CalVer terminology: `YYYY`, `YY`, `0Y`, `MM`,
 
 Controls the time granularity of the version base.
 
-- `"year"` â€” base is `YYYY` (e.g. `2026`)
-- `"month"` â€” base is `YYYY.MM` (e.g. `2026.04`)
-- `"week"` â€” base is `YYYY.WW` (e.g. `2026.16`)
-- `"day"` â€” base is `YYYY.MM.DD` (e.g. `2026.04.15`)
+- `"year"`: base is `YYYY` (e.g. `2026`)
+- `"month"`: base is `YYYY.MM` (e.g. `2026.04`)
+- `"week"`: base is `YYYY.WW` (e.g. `2026.16`)
+- `"day"`: base is `YYYY.MM.DD` (e.g. `2026.04.15`)
 
 ```toml
-# Year mode â€” annual cadence
+# Year mode: annual cadence
 [tool.calver-scm]
 mode = "year"
-# -> 2026.0, 2026.1.dev3 â€¦
+# -> 2026.0, 2026.1.dev3 ...
 
-# Month mode (default) â€” good for most projects
+# Month mode (default): good for most projects
 [tool.calver-scm]
 mode = "month"
-# â†’ 2026.04.0, 2026.04.1.dev3, 2026.05.0.dev1 â€¦
+# -> 2026.04.0, 2026.04.1.dev3, 2026.05.0.dev1 ...
 
-# Week mode â€” weekly cadence
+# Week mode: weekly cadence
 [tool.calver-scm]
 mode = "week"
-# -> 2026.16.0, 2026.16.1.dev2 â€¦
+# -> 2026.16.0, 2026.16.1.dev2 ...
 
-# Day mode â€” useful for projects that release frequently
+# Day mode: useful for projects that release frequently
 [tool.calver-scm]
 mode = "day"
-# â†’ 2026.04.15.0, 2026.04.15.1.dev2, 2026.04.16.0.dev1 â€¦
+# -> 2026.04.15.0, 2026.04.15.1.dev2, 2026.04.16.0.dev1 ...
 ```
 
 ### `scheme`
@@ -297,34 +297,34 @@ scheme = "YYYY.0W"
 When `true`, the patch number increments from the last tag within the same period. When `false`, patch is always `0` and only the `.devN` distance distinguishes pre-release builds.
 
 ```toml
-# patch = true (default) â€” each build within a period gets a unique patch number
+# patch = true (default): each build within a period gets a unique patch number
 [tool.calver-scm]
 patch = true
-# tag v2026.04.2, then 3 commits later â†’ 2026.04.3.dev3
+# tag v2026.04.2, then 3 commits later -> 2026.04.3.dev3
 
-# patch = false â€” patch stays 0, only devN changes
+# patch = false: patch stays 0, only devN changes
 [tool.calver-scm]
 patch = false
-# tag v2026.04.2, then 3 commits later â†’ 2026.04.0.dev3
+# tag v2026.04.2, then 3 commits later -> 2026.04.0.dev3
 ```
 
 ### `fallback`
 
 Controls what happens when no tag exists yet in the repository.
 
-- `"dev"` â€” emits `YYYY.MM.0.devN` where N is the total commit count *(default)*
-- `"date"` â€” emits `YYYY.MM.0` with no dev segment, useful for initial releases
+- `"dev"`: emits `YYYY.MM.0.devN` where N is the total commit count *(default)*
+- `"date"`: emits `YYYY.MM.0` with no dev segment, useful for initial releases
 
 ```toml
-# fallback = "dev" (default) â€” makes it clear this is a pre-release build
+# fallback = "dev" (default): makes it clear this is a pre-release build
 [tool.calver-scm]
 fallback = "dev"
-# 12 commits, no tag yet â†’ 2026.04.0.dev12
+# 12 commits, no tag yet -> 2026.04.0.dev12
 
-# fallback = "date" â€” emits a clean version even before the first tag
+# fallback = "date": emits a clean version even before the first tag
 [tool.calver-scm]
 fallback = "date"
-# 12 commits, no tag yet â†’ 2026.04.0
+# 12 commits, no tag yet -> 2026.04.0
 ```
 
 ### `tag_prefix`
@@ -332,15 +332,15 @@ fallback = "date"
 The string that must prefix a tag for it to be recognised as a CalVer tag. Set to `""` if your tags have no prefix.
 
 ```toml
-# tag_prefix = "v" (default) â€” tags like v2026.04.0
+# tag_prefix = "v" (default): tags like v2026.04.0
 [tool.calver-scm]
 tag_prefix = "v"
 
-# No prefix â€” tags like 2026.04.0
+# No prefix: tags like 2026.04.0
 [tool.calver-scm]
 tag_prefix = ""
 
-# Custom prefix â€” tags like release-2026.04.0
+# Custom prefix: tags like release-2026.04.0
 [tool.calver-scm]
 tag_prefix = "release-"
 ```
@@ -349,8 +349,8 @@ tag_prefix = "release-"
 
 Controls which timezone is used to compute the date segment.
 
-- `"UTC"` â€” default; deterministic across environments
-- `"local"` â€” machine local timezone
+- `"UTC"`: default; deterministic across environments
+- `"local"`: machine local timezone
 - Any valid IANA timezone, e.g. `"Europe/London"`, `"America/New_York"`
 
 ```toml
@@ -371,7 +371,7 @@ timezone = "Pacific/Auckland"
 
 ## Environment variable overrides
 
-Every option can be overridden at build time without touching `pyproject.toml` â€” handy for CI pipelines.
+Every option can be overridden at build time without touching `pyproject.toml`, which is handy for CI pipelines.
 
 | Variable                | Equivalent option          |
 |-------------------------|----------------------------|
@@ -398,11 +398,11 @@ Environment variables take precedence over `pyproject.toml`.
 
 ## Local scheme
 
-`calver_scm` controls the **public** version segment only. The `+dirty` suffix is handled separately by setuptools-scm's built-in local schemes. Pick whichever suits you:
+`calver-scm` controls the **public** version segment only. The `+dirty` suffix is handled separately by setuptools-scm's built-in local schemes. Pick whichever suits you:
 
 ```toml
 [tool.setuptools_scm]
-version_scheme = "calver_scm"
+version_scheme = "calver-scm"
 local_scheme   = "dirty-tag"         # +dirty on uncommitted changes (recommended)
 # local_scheme = "no-local-version"  # suppress the local segment entirely
 # local_scheme = "node-and-date"     # +g1a2b3c4.d20260415 (setuptools-scm default)
@@ -412,9 +412,9 @@ local_scheme   = "dirty-tag"         # +dirty on uncommitted changes (recommende
 
 ## Requirements
 
-- Python â‰¥ 3.10
-- setuptools-scm â‰¥ 10.0.5
-- `tomli` â‰¥ 2.4.1 on Python < 3.11 (the stdlib `tomllib` is used on 3.11+)
+- Python >= 3.10
+- setuptools-scm >= 10.0.5
+- `tomli` >= 2.4.1 on Python < 3.11 (the stdlib `tomllib` is used on 3.11+)
 
 ---
 


### PR DESCRIPTION
Refines the README documentation by fixing inconsistent punctuation and symbols, normalising configuration examples, and improving clarity in descriptions. Additionally, updates the requirements section to use standardised comparison operators.