### PR TITLE
ci: add pyupgrade hook to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,13 @@ repos:
     hooks:
       - id: typos
 
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.2
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py310-plus
+
   - repo: local
     hooks:
       - id: ruff-check

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
 
 @pytest.fixture(autouse=True)
-def clear_config_cache() -> Generator[None, None, None]:
+def clear_config_cache() -> Generator[None]:
     """Clear cached config reads between tests for deterministic behaviour."""
     _load_calver_config.cache_clear()
     yield


### PR DESCRIPTION
- Integrate `pyupgrade` hook (v3.21.2) with `--py310-plus` argument for upgrading syntax to Python 3.10+.