### PR TITLE
ci: standardize `permissions` configuration across workflows

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -26,12 +26,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build and test distributions
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,6 +11,8 @@ on:
       - "tests/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ on:
       - "tests/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Ruff + Mypy + Typos

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,12 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-dist.yml
-    permissions:
-      contents: read
 
   publish:
     name: Publish to PyPI
@@ -19,7 +20,6 @@ jobs:
       name: pypi
     permissions:
       id-token: write
-      contents: read
       attestations: write
     steps:
       - name: Install uv

--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/renovate-config.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-renovate-config:
     name: Validate renovate.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,9 @@ on:
       - "tests/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Python ${{ matrix.python-version }}


### PR DESCRIPTION
- Add `contents: read` permission explicitly to all workflows for consistency and clarity.
- Remove redundant or misplaced `permissions` entries where unnecessary.

closes #88 