### PR TITLE
ci: add actionlint hook and update branch syntax in workflow config

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -13,7 +13,7 @@ on:
       - "tests/**"
 
   push:
-    branches: main
+    branches: [main]
     paths:
       - ".github/workflows/build-dist.yml"
       - "pyproject.toml"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,12 @@ repos:
         args:
           - --py310-plus
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.8
+    hooks:
+      - id: actionlint
+        files: ^\.github/workflows/.*\.ya?ml$
+
   - repo: local
     hooks:
       - id: ruff-check


### PR DESCRIPTION
- Add `actionlint` hook (v1.7.8) to `.pre-commit-config.yaml` for validating GitHub Actions workflows.
- Update branch declaration in `build-dist.yml` to use array syntax for consistency.