### PR TITLE
ci: validate release tags and update publish conditions in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: build-and-test
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -22,6 +22,15 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - name: Validate tag is semver (vX.Y.Z)
+        run: |
+          TAG="${{ github.ref_name }}"
+          if ! echo "$TAG" | grep -Pq '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
+            echo "::error::Tag '$TAG' is not a valid semver tag (expected vX.Y.Z). Aborting publish."
+            exit 1
+          fi
+          echo "Tag '$TAG' is valid semver. Proceeding with publish."
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0
 


### PR DESCRIPTION
- Add a step to ensure release tags follow valid semver (vX.Y.Z) before publishing.
- Update `if` condition to trigger publication only on `release` events with tags.